### PR TITLE
fix: Added panic handler to `Gather` method

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -70,6 +70,12 @@ func (e *exporter) WithContext(ctx context.Context) Exporter {
 
 // Gather implements prometheus.Gatherer.
 func (e *exporter) Gather() ([]*dto.MetricFamily, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in Gather", r)
+		}
+	}()
+
 	var (
 		metricChan = make(chan Metric, capMetricChan)
 		errs       prometheus.MultiError


### PR DESCRIPTION
I added a `panic()` handler to the `Gather()` method to gracefully handle the panics thrown during
collection.  We will see if this takes care of the issue.

closes #3